### PR TITLE
[PR] HistoriesScreen navigationPadding 추가

### DIFF
--- a/feature/histories/src/main/kotlin/com/tedd/todo_project/histories/HistoriesScreen.kt
+++ b/feature/histories/src/main/kotlin/com/tedd/todo_project/histories/HistoriesScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -33,7 +34,11 @@ fun HistoriesScreen(
 ) {
     val uiState by uiState().collectAsStateWithLifecycle()
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding()
+    ) {
         HistoriesTopAppBar(
             title = stringResource(R.string.history),
             onNavigationClick = { viewModel.onEvent(HistoriesScreenEvent.OnNavigateBack) }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add `navigationBarsPadding` to the `HistoriesScreen` component to handle padding for navigation bars.

### Why are these changes being made?
This change ensures that the content on the `HistoriesScreen` is displayed correctly without being obstructed by the system's navigation bars, improving the UI experience on devices with navigation bars.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->